### PR TITLE
Fix code scanning alert no. 20: Incomplete regular expression for hostnames

### DIFF
--- a/certora/run.js
+++ b/certora/run.js
@@ -123,7 +123,7 @@ async function runCertora(spec, contract, files, options = []) {
   stream.end();
 
   // write results in markdown format
-  writeEntry(spec, contract, code || signal, (await output).match(/https:\/\/prover.certora.com\/output\/\S*/)?.[0]);
+  writeEntry(spec, contract, code || signal, (await output).match(/https:\/\/prover\.certora\.com\/output\/\S*/)?.[0]);
 
   // write all details
   console.error(`+ certoraRun ${args.join(' ')}\n` + (await output));


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/openzeppelin-contracts/security/code-scanning/20](https://github.com/Dargon789/openzeppelin-contracts/security/code-scanning/20)

To fix the problem, we need to escape the `.` character in the regular expression to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.` in the regular expression. This change ensures that the regular expression will only match the intended domain `certora.com` and not any other unintended domains.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete regular expression for matching hostnames in Certora Prover URLs.